### PR TITLE
Prevent text input from escape key in Safari

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -829,6 +829,7 @@ $(document).keypress(function(event) {
   if (!$("#wordsInput").is(":focus")) return;
   if (event["keyCode"] == 13) return;
   if (event["keyCode"] == 32) return;
+  if (event["keyCode"] == 27) return;
   //start the test
   if (currentInput == "" && inputHistory.length == 0) {
     if (firebase.auth().currentUser != null) {


### PR DESCRIPTION
Currently, in Safari, whenever you hit the escape key while the text field is focused/focusable, the text `Escape` is appended to the text cursor in the text field.