### PR TITLE
Scroll Longform text

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -380,7 +380,6 @@ function updateCaretPosition() {
       top: newTop - middlePos,
       behavior: 'smooth'
     })
-    console.log("run")
   }
 
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -16,7 +16,6 @@ let afkDetected = false;
 let errorsPerSecond = [];
 let currentErrorCount = 0;
 let resultVisible = false;
-let browserHeight = document.documentElement.clientHeight;
 
 let accuracyStats = {
   correct: 0,
@@ -372,9 +371,11 @@ function updateCaretPosition() {
     left: newLeft
   }, duration)
 
+  let browserHeight = window.innerHeight;
   let middlePos = (browserHeight / 2) - $("#caret").outerHeight()/2;
+  let contentHeight = document.body.scrollHeight;
   
-  if (newTop >= middlePos && window.innerHeight > browserHeight) {
+  if (newTop >= middlePos &&  contentHeight > browserHeight) {
     window.scrollTo({
       left: 0,
       top: newTop - middlePos,

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -16,6 +16,7 @@ let afkDetected = false;
 let errorsPerSecond = [];
 let currentErrorCount = 0;
 let resultVisible = false;
+let browserHeight = document.documentElement.clientHeight;
 
 let accuracyStats = {
   correct: 0,
@@ -371,14 +372,15 @@ function updateCaretPosition() {
     left: newLeft
   }, duration)
 
-  let middlePos = (document.documentElement.clientHeight / 2);
+  let middlePos = (browserHeight / 2) - $("#caret").outerHeight()/2;
   
-  if (newTop >= middlePos) {
+  if (newTop >= middlePos && window.innerHeight > browserHeight) {
     window.scrollTo({
       left: 0,
       top: newTop - middlePos,
       behavior: 'smooth'
     })
+    console.log("run")
   }
 
 }

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -371,6 +371,16 @@ function updateCaretPosition() {
     left: newLeft
   }, duration)
 
+  let middlePos = (document.documentElement.clientHeight / 2);
+  
+  if (newTop >= middlePos) {
+    window.scrollTo({
+      left: 0,
+      top: newTop - middlePos,
+      behavior: 'smooth'
+    })
+  }
+
 }
 
 function countChars() {


### PR DESCRIPTION
The window will scroll after the cursors passes text that is beyond the middle of the page, keeping the active text in the middle of the window.

fixes https://github.com/Miodec/monkey-type/issues/67