### PR TITLE
Add caret options

### DIFF
--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -321,7 +321,6 @@ a:hover {
   @extend #caret, .block;
   background: transparent;
   border: 1px solid var(--caret-color);
-  animation-name: caretOutlineFlash;
 }
 
 #caret.underline{
@@ -348,19 +347,10 @@ a:hover {
 
 @keyframes caretFlash {
   0%, 100% {
-    background: transparent;
+    opacity: 0;
   }
   50% {
-    background: var(--caret-color);
-  }
-}
-
-@keyframes caretOutlineFlash {
-  0%, 100% {
-    border-color: transparent;
-  }
-  50% {
-    border-color: var(--caret-color);
+    opacity: 1;
   }
 }
 

--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -311,6 +311,26 @@ a:hover {
   // transition: 0.05s;
 }
 
+#caret.block{
+  width: .7em;
+  margin-left: 0.25em;
+  border-radius: 0;
+}
+
+#caret.outline{
+  @extend #caret, .block;
+  background: transparent;
+  border: 1px solid var(--caret-color);
+  animation-name: caretOutlineFlash;
+}
+
+#caret.underline{
+  height: 2px;
+  width: .7em;
+  margin-top: 1.2em;
+  padding-left: .5em;
+}
+
 #caret.size125{
   height: 2rem;
   width: 2px;
@@ -327,14 +347,20 @@ a:hover {
 }
 
 @keyframes caretFlash {
-  0% {
+  0%, 100% {
     background: transparent;
   }
   50% {
     background: var(--caret-color);
   }
-  100% {
-    background: transparent;
+}
+
+@keyframes caretOutlineFlash {
+  0%, 100% {
+    border-color: transparent;
+  }
+  50% {
+    border-color: var(--caret-color);
   }
 }
 
@@ -942,7 +968,7 @@ key {
       margin-left: 2rem;
       display: grid;
       grid-auto-flow: column;
-      grid-template-columns: 1fr 1fr;
+      grid-auto-columns: 1fr;
       gap: .5rem;
       grid-area: buttons;
       .button{

--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -299,7 +299,6 @@ a:hover {
 }
 
 #caret {
-  width: 2px;
   height: 1.5rem;
   background: var(--caret-color);
   animation-name: caretFlash;
@@ -309,6 +308,11 @@ a:hover {
   position: absolute;
   border-radius: var(--roundness);
   // transition: 0.05s;
+  transform-origin: top left;
+}
+
+#caret.default{
+  width: 2px;
 }
 
 #caret.block{
@@ -325,24 +329,25 @@ a:hover {
 
 #caret.underline{
   height: 2px;
-  width: .7em;
-  margin-top: 1.2em;
-  padding-left: .5em;
+  width: 0.8em;
+  margin-top: 1.3em;
+  margin-left: 0.3em;
 }
 
+#caret.underline.size125{margin-top: 1.8em;}
+#caret.underline.size15{margin-top: 2.1em;}
+#caret.underline.size2{margin-top: 2.7em;}
+
 #caret.size125{
-  height: 2rem;
-  width: 2px;
+  transform: scale(1.25);
 }
 
 #caret.size15{
-  height: 2.25rem;
-  width: 3px;
+  transform: scale(1.45);
 }
 
 #caret.size2{
-  height: 3rem;
-  width: 4px;
+  transform: scale(1.9);
 }
 
 @keyframes caretFlash {

--- a/public/index.html
+++ b/public/index.html
@@ -262,6 +262,16 @@
             <div class="button off" tabindex="0" onclick="this.blur();">off</div>
           </div>
         </div>
+        <div class="section caretStyle" section="">
+          <h1>caret style</h1>
+          <div class="text">What the caret will look like in the test</div>
+          <div class="buttons">
+            <div class="button" caret="default" tabindex="0" onclick="this.blur();">|</div>
+            <div class="button" caret="block" tabindex="0" onclick="this.blur();">▮</div>
+            <div class="button" caret="outline" tabindex="0" onclick="this.blur();">▯</div>
+            <div class="button" caret="underline" tabindex="0" onclick="this.blur();">_</div>
+          </div>
+        </div>
         <div class="section quickTab">
           <h1>quick tab mode</h1>
           <div class="text">Press <key>tab</key> to quickly restart the test. This function disables tab navigation on some parts of the website.</div>

--- a/public/js/commandline.js
+++ b/public/js/commandline.js
@@ -59,6 +59,15 @@ let commands = {
             }
         },
         {
+            id: "changeCaretStyle",
+            display: "Change caret...",
+            subgroup: true,
+            exec: () => {
+                currentCommands.push(commandsCaretStyle);
+                showCommandLine();
+            }
+        },
+        {
             id: "changeTheme",
             display: "Change theme...",
             subgroup: true,
@@ -188,6 +197,40 @@ let commandsDifficulty = {
     ]
 }
 
+
+let commandsCaretStyle = {
+    title: "Change caret...",
+    list: [
+        {
+            id: "setCaretStyleDefault",
+            display: "line",
+            exec: () => {
+                setCaretStyle('default');
+            }
+        },
+        {
+            id: "setCaretStyleBlock",
+            display: "block",
+            exec: () => {
+                setCaretStyle('block');
+            }
+        },
+        {
+            id: "setCaretStyleOutline",
+            display: "outline-block",
+            exec: () => {
+                setCaretStyle('outline');
+            }
+        },
+        {
+            id: "setCaretStyleUnderline",
+            display: "underline",
+            exec: () => {
+                setCaretStyle('underline');
+            }
+        }
+    ]
+}
 
 let commandsWordCount = {
     title: "Change word count...",

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -313,7 +313,7 @@ function showCaret() {
 
 function stopCaretAnimation() {
   $("#caret").css("animation-name", "none");
-  $("#caret").css("background-color", "var(--caret-color)");
+  $("#caret").css("opacity", "1");
 }
 
 function startCaretAnimation() {

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -21,6 +21,7 @@ function updateSettingsPage(){
     setActiveLanguageButton();
     setActiveFontSizeButton();
     setActiveDifficultyButton();
+    setActiveCaretStyleButton();
 
     if (config.showKeyTips) {
         $(".pageSettings .tip").removeClass('hidden');
@@ -49,6 +50,11 @@ function setActiveDifficultyButton() {
 function setActiveLanguageButton() {
     $(`.pageSettings .section.languages .language`).removeClass('active');
     $(`.pageSettings .section.languages .language[language=${config.language}]`).addClass('active'); 
+}
+
+function setActiveCaretStyleButton() {
+    $(`.pageSettings .section.caretStyle .buttons .button`).removeClass('active');
+    $(`.pageSettings .section.caretStyle .buttons .button[caret=`+config.caretStyle+`]`).addClass('active');
 }
 
 function setSettingsButton(buttonSection,tf) {
@@ -175,4 +181,12 @@ $(document).on("click",".pageSettings .section.difficulty .button", (e) => {
     setDifficulty(difficulty);
     showNotification('Difficulty changed', 1000);
     setActiveDifficultyButton();
+})
+
+//caret style
+$(document).on("click",".pageSettings .section.caretStyle .button", (e) => {
+    let caretStyle = $(e.currentTarget).attr('caret');
+    setCaretStyle(caretStyle);
+    showNotification('Caret style updated', 1000);
+    setActiveCaretStyleButton();
 })

--- a/public/js/userconfig.js
+++ b/public/js/userconfig.js
@@ -41,6 +41,7 @@ function loadConfigFromCookie() {
         changeLanguage(newConfig.language,true);
         changeFontSize(newConfig.fontSize,true);
         setFreedomMode(newConfig.freedomMode,true);
+        setCaretStyle(newConfig.caretStyle,true);
         setDifficulty(newConfig.difficulty,true);
         if(newConfig.resultFilters == null || newConfig.resultFilters == undefined){
             newConfig.resultFilters = ["all"];
@@ -64,6 +65,28 @@ function setDifficulty(diff, nosave){
     }
     config.difficulty = diff;
     restartTest();
+    if(!nosave) saveConfigToCookie();
+}
+
+function setCaretStyle(caretStyle, nosave) {
+    if (caretStyle == null || caretStyle == undefined) {
+        caretStyle = 'default';
+    }
+    config.caretStyle = caretStyle;
+    $("#caret").removeClass('default');
+    $("#caret").removeClass('underline');
+    $("#caret").removeClass('outline');
+    $("#caret").removeClass('block');
+
+    if (caretStyle == 'default') {
+        $("#caret").addClass('default');
+    } else if (caretStyle == 'block') {   
+        $("#caret").addClass('block');     
+    } else if (caretStyle == 'outline') {
+        $("#caret").addClass('outline');
+    } else if (caretStyle == 'underline') {
+        $("#caret").addClass('underline');
+    }
     if(!nosave) saveConfigToCookie();
 }
 


### PR DESCRIPTION
**New Feature** Adds caret option feature.
* 3 additional caret types
  * Block
  * Outline Block
  * Underline
* Adds settings selection of caret
![image](https://user-images.githubusercontent.com/32944224/83224652-cabc5b80-a132-11ea-8005-ddd365fc526c.png)
* Adds command line support for caret selection
![gif](https://user-images.githubusercontent.com/32944224/83225341-67cbc400-a134-11ea-911e-bf9b1cfcfdb4.gif)
* Saved as all other preferences are
* Works with all font sizes
* Changed caret animation from color -> opacity to support all caret types
* Changed caret scaling to transform via scale instead of em to support all caret types
* Changed settings buttons to auto columns versus template to scale evenly with any number of buttons

closes https://github.com/Miodec/monkey-type/issues/90 - Add cursor selection feature request