### PR TITLE
Add a timeout to call the updateFavicon fn

### DIFF
--- a/public/js/userconfig.js
+++ b/public/js/userconfig.js
@@ -300,7 +300,9 @@ function previewTheme(name) {
 function setTheme(name,nosave) {
     config.theme = name;
     $("#currentTheme").attr("href", `themes/${name}.css`);
-    updateFavicon(32,14);
+    setTimeout(() => {
+      updateFavicon(32,14);
+    }, 500);
     try{
         firebase.analytics().logEvent('changedTheme', {
             theme: name


### PR DESCRIPTION
This is needed because the theme change claimed about 100ms on my tests. So, when the favicon update runs, there's no change for the root style that what he sees.

I do think could be a better solution to this, but to a temporary solution i think its valid.