### PR TITLE
Adds caps lock backspace mode and fixes some caps lock bugs.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1705,6 +1705,20 @@
                 </div>
               </div>
             </div>
+            <div class="section capsLockBackspace">
+              <h1>caps lock backspace</h1>
+              <div class="text">
+                Makes caps lock act like backspace.
+              </div>
+              <div class="buttons">
+                <div class="button off" tabindex="0" onclick="this.blur();">
+                  off
+                </div>
+                <div class="button on" tabindex="0" onclick="this.blur();">
+                  on
+                </div>
+              </div>
+            </div>
             <div class="section layout">
               <h1>layout override</h1>
               <div class="buttons"></div>

--- a/public/js/commandline.js
+++ b/public/js/commandline.js
@@ -282,6 +282,13 @@ let commands = {
       },
     },
     {
+      id: "toggleCapsLockBackspace",
+      display: "Toggle caps lock backspace",
+      exec: () => {
+        toggleCapsLockBackspace();
+      },
+    },
+    {
       id: "changeLayout",
       display: "Change layout...",
       subgroup: true,

--- a/public/js/misc.js
+++ b/public/js/misc.js
@@ -190,6 +190,10 @@ function capitalizeFirstLetter(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+function isASCIILetter(c) {
+  return c.length === 1 && /[a-z]/i.test(c);
+}
+
 function kogasa(cov) {
   return (
     100 * (1 - Math.tanh(cov + Math.pow(cov, 3) / 3 + Math.pow(cov, 5) / 5))

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -569,7 +569,8 @@ function emulateLayout(event) {
     if (isCapsLockHeld) return isASCIILetter(newKeyPreview) !== event.shiftKey;
     return event.shiftKey;
   }
-  if (config.layout == "default" || event.key === " ") return event;
+  if (config.layout === "default" || event.key === " " || event.key === "Enter")
+    return event;
   const qwertyMasterLayout = {
     Backquote: "`~",
     Digit1: "1!",

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -580,7 +580,7 @@ function emulateLayout(event) {
   if (event.key === " " || event.key === "Enter")
     return event;
   if (config.layout === "default") {
-    //override the shift modifier for the default layout if needed
+    //override the caps lock modifier for the default layout if needed
     if (config.capsLockBackspace && isASCIILetter(event.key)) {
       replaceEventKey(
         event,

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -182,6 +182,10 @@ settingsGroups.smoothLineScroll = new SettingsGroup(
   "smoothLineScroll",
   setSmoothLineScroll
 );
+settingsGroups.capsLockBackspace = new SettingsGroup(
+  "capsLockBackspace",
+  setCapsLockBackspace
+);
 settingsGroups.layout = new SettingsGroup("layout", changeLayout);
 settingsGroups.language = new SettingsGroup("language", changeLanguage);
 settingsGroups.fontSize = new SettingsGroup("fontSize", changeFontSize);

--- a/public/js/userconfig.js
+++ b/public/js/userconfig.js
@@ -33,6 +33,7 @@ let defaultConfig = {
   // readAheadMode: false,
   caretStyle: "default",
   flipTestColors: false,
+  capsLockBackspace: false,
   layout: "default",
   confidenceMode: "off",
   timerStyle: "text",
@@ -144,6 +145,7 @@ function applyConfig(configObj) {
     changeWordCount(configObj.words, true);
     changeMode(configObj.mode, true);
     changeLanguage(configObj.language, true);
+    setCapsLockBackspace(configObj.capsLockBackspace, true);
     changeLayout(configObj.layout, true);
     changeFontSize(configObj.fontSize, true);
     setFreedomMode(configObj.freedomMode, true);
@@ -868,6 +870,18 @@ function changeLanguage(language, nosave) {
     console.log("Analytics unavailable");
   }
   if (!nosave) saveConfigToCookie();
+}
+
+function setCapsLockBackspace(capsLockBackspace, nosave) {
+  if (capsLockBackspace == null || capsLockBackspace == undefined) {
+    capsLockBackspace = false;
+  }
+  config.capsLockBackspace = capsLockBackspace;
+  if (!nosave) saveConfigToCookie();
+}
+
+function toggleCapsLockBackspace() {
+  setCapsLockBackspace(!config.capsLockBackspace, false);
 }
 
 function changeLayout(layout, nosave) {

--- a/public/js/userconfig.js
+++ b/public/js/userconfig.js
@@ -873,7 +873,7 @@ function changeLanguage(language, nosave) {
 }
 
 function setCapsLockBackspace(capsLockBackspace, nosave) {
-  if (capsLockBackspace == null || capsLockBackspace == undefined) {
+  if (capsLockBackspace === null || capsLockBackspace === undefined) {
     capsLockBackspace = false;
   }
   config.capsLockBackspace = capsLockBackspace;


### PR DESCRIPTION
Features added:

1. Treats caps lock as backspace if this new setting is on. Caps lock is now emulated on both default and emulated layouts.

2. Adds the capability to "unshift" from upper to lower case with caps lock on. Both default and emulated layouts should now behave as expected for all caps lock-related typing.

Simultaneous bug fixes:

1. Fixes a bug where shifting between upper and lower case would sometimes be wrong while caps lock is on. For example, with caps lock turned on in emulated Colemak, the O key would type lowercase o because it corresponds to a symbol and not a letter in Qwerty.

2. Fixes a bug where pressing the enter key in an emulated layout would result in a console error.