### PR TITLE
Moved notes on contributing to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,18 @@
 1. Head to [the firebase console](https://console.firebase.google.com/u/0/) and make a new project (the project name doesnt really matter, but just name it `monkey-type`). You dont need to enable analytics for it.
 2. Install the [Firebase Command Line Interface](https://firebase.google.com/docs/cli), and use `firebase login` to log in to the same google account as you just used to make the project.
 3. Git clone the project and make sure to rename `.firebaserc_example` to `.firebaserc` and change the project name inside to your firebase project name you just created.
+
    - If `.firebaserc_example` does not exist after cloning, create your own:
-     `{ "projects": { "default": "monkey-type-dev-67af4", "live": "monkey-type" } }`
+
+     {
+     "projects": {
+     "default": "monkey-type-dev-67af4",
+     "live": "monkey-type"
+     }
+     }
+
    - The "live" option in `.firebaserc_example` is not necessary.
+
 4. Run `firebase serve` to start a local server on port 5000. Use ctrl+c to stop it.
 5. Run `firebase use default` if you run into any errors on step 5.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,14 +6,14 @@
 
    - If `.firebaserc_example` does not exist after cloning, create your own:
 
-````.firebaserc
-     {
-         "projects": {
-             "default": "monkey-type-dev-67af4",
-             "live": "monkey-type"
-         }
-     }
-     ```
+   ```.firebaserc
+        {
+            "projects": {
+                "default": "monkey-type-dev-67af4",
+                "live": "monkey-type"
+            }
+        }
+   ```
 
    - The "live" option in `.firebaserc_example` is not necessary.
 
@@ -26,4 +26,3 @@
 2. Install [Prettier](https://prettier.io/docs/en/install.html). Its a code formatter, and it will make sure that we avoid any whitespace or formatting issues when merging code.
 
 That should be it. If you run into any problems, let me know.
-````

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# how to contribute
+
+1. Head to [the firebase console](https://console.firebase.google.com/u/0/) and make a new project (the project name doesnt really matter, but just name it `monkey-type`). You dont need to enable analytics for it.
+2. Install the [Firebase Command Line Interface](https://firebase.google.com/docs/cli), and use `firebase login` to log in to the same google account as you just used to make the project.
+3. Git clone the project and make sure to rename `.firebaserc_example` to `.firebaserc` and change the project name inside to your firebase project name you just created.
+   - If `.firebaserc_example` does not exist after cloning, create your own:
+     `{ "projects": { "default": "monkey-type-dev-67af4", "live": "monkey-type" } }`
+   - The "live" option in `.firebaserc_example` is not necessary.
+4. Run `firebase serve` to start a local server on port 5000. Use ctrl+c to stop it.
+5. Run `firebase use default` if you run into any errors on step 5.
+
+## standards & conventions
+
+1. Use a SCSS compiler. For VSCode I recommend `Easy Sass` or `Live Sass Compiler` extension.
+2. Install [Prettier](https://prettier.io/docs/en/install.html). Its a code formatter, and it will make sure that we avoid any whitespace or formatting issues when merging code.
+
+That should be it. If you run into any problems, let me know.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 ## Project Setup
 
-1.  [Make a new Firebase project. ](https://console.firebase.google.com/u/0/)
+1.  [Create a new Firebase project. ](https://console.firebase.google.com/u/0/)
 
     - The project name doesn't really matter, but just name it `monkey-type`.
-    - Google Analytics not necessary.
+    - Google Analytics is not necessary.
 
 2.  [Install the Firebase CLI](https://firebase.google.com/docs/cli)
-3.  Run `firebase login` on your terminal to log in to the same google account as you just used to make the project.
-4.  Git clone the project.
+3.  Run `firebase login` on your terminal to log in to the same google account as you just used to create the project.
+4.  Git clone this project.
 5.  Rename `.firebaserc_example` to `.firebaserc` and change the project name of default to the firebase project id you just created.
 
     - If `.firebaserc_example` does not exist after cloning, create your own with:
@@ -34,4 +34,4 @@
 
 ## Questions
 
-That should be it. If you run into any problems, let [me](https://github.com/Miodec) know.
+If you run into any problems, let [me](https://github.com/Miodec) know.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,14 @@
 
    - If `.firebaserc_example` does not exist after cloning, create your own:
 
+````.firebaserc
      {
-     "projects": {
-     "default": "monkey-type-dev-67af4",
-     "live": "monkey-type"
+         "projects": {
+             "default": "monkey-type-dev-67af4",
+             "live": "monkey-type"
+         }
      }
-     }
+     ```
 
    - The "live" option in `.firebaserc_example` is not necessary.
 
@@ -24,3 +26,4 @@
 2. Install [Prettier](https://prettier.io/docs/en/install.html). Its a code formatter, and it will make sure that we avoid any whitespace or formatting issues when merging code.
 
 That should be it. If you run into any problems, let me know.
+````

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,37 @@
-# how to contribute
+# Contributing
 
-1. Head to [the firebase console](https://console.firebase.google.com/u/0/) and make a new project (the project name doesnt really matter, but just name it `monkey-type`). You dont need to enable analytics for it.
-2. Install the [Firebase Command Line Interface](https://firebase.google.com/docs/cli), and use `firebase login` to log in to the same google account as you just used to make the project.
-3. Git clone the project and make sure to rename `.firebaserc_example` to `.firebaserc` and change the project name inside to your firebase project name you just created.
+## Project Setup
 
-   - If `.firebaserc_example` does not exist after cloning, create your own:
+1.  [Make a new Firebase project. ](https://console.firebase.google.com/u/0/)
 
-   ```.firebaserc
-        {
-            "projects": {
-                "default": "monkey-type-dev-67af4",
-                "live": "monkey-type"
-            }
-        }
-   ```
+    - The project name doesn't really matter, but just name it `monkey-type`.
+    - Google Analytics not necessary.
 
-   - The "live" option in `.firebaserc_example` is not necessary.
+2.  [Install the Firebase CLI](https://firebase.google.com/docs/cli)
+3.  Run `firebase login` on your terminal to log in to the same google account as you just used to make the project.
+4.  Git clone the project.
+5.  Rename `.firebaserc_example` to `.firebaserc` and change the project name of default to the firebase project id you just created.
 
-4. Run `firebase serve` to start a local server on port 5000. Use ctrl+c to stop it.
-5. Run `firebase use default` if you run into any errors on step 5.
+    - If `.firebaserc_example` does not exist after cloning, create your own with:
 
-## standards & conventions
+    ```.firebaserc
+     {
+         "projects": {
+             "default": "your-firebase-project-id",
+         }
+     }
+    ```
+
+    - Run `firebase projects:list` to find your firebase project id.
+
+6.  Run `firebase serve` to start a local server on port 5000. Use ctrl+c to stop it.
+    - Run `firebase use default` if you run into any errors for this.
+
+## Standards & Conventions
 
 1. Use a SCSS compiler. For VSCode I recommend `Easy Sass` or `Live Sass Compiler` extension.
 2. Install [Prettier](https://prettier.io/docs/en/install.html). Its a code formatter, and it will make sure that we avoid any whitespace or formatting issues when merging code.
 
-That should be it. If you run into any problems, let me know.
+## Questions
+
+That should be it. If you run into any problems, let [me](https://github.com/Miodec) know.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,4 @@ If you wish to support further development and feeling extra awesome, you can do
 
 # how to contribute
 
-1. Head to [the firebase console](https://console.firebase.google.com/u/0/) and make a new project (the project name doesnt really matter, but just name it `monkey-type`). You dont need to enable analytics for it.
-2. Install the [Firebase Command Line Interface](https://firebase.google.com/docs/cli), and use `firebase login` to log in to the same google account as you just used to make the project.
-3. Git clone the project and make sure to rename `.firebaserc_example` to `.firebaserc` and change the project name inside to your firebase project name you just created.
-4. Make sure you use a SCSS compiler. For VSCode I recommend `Easy Sass` or `Live Sass Compiler` extension.
-5. Run `firebase serve` to start a local server on port 5000. Use ctrl+c to stop it.
-6. Make sure to install `Prettier`. Its a code formatter, and it will make sure that we avoid any whitespace or formatting issues when merging code.
-
-That should be it. If you run into any problems, let me know.
+Refer to CONTRIBUTING.md.


### PR DESCRIPTION
- Moved "how to contribute" from README.md to CONTRIBUTING.md

- Restructured the original steps for more info, especially with troubles on .firebaserc_example

Not related to any open Issue but saw that the Community Profile under 'Insights' could use a CONTRIBUTING.md so thought I'd help make one. :)