### PR TITLE
Feature: Indicate Typos

### DIFF
--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -1686,6 +1686,19 @@ key {
 
 .word letter.incorrect {
   color: var(--error-color);
+  position:relative;
+}
+
+.word letter.incorrect hint {
+  position: absolute;
+  bottom: -1.2em;
+  color: var(--text-color);
+  line-height: 1em;
+  font-size: .8em;
+  text-shadow: none;
+  padding: 1px;
+  left: 0;
+  opacity: .5;
 }
 
 .word letter.incorrect.extra {

--- a/public/css/style.scss
+++ b/public/css/style.scss
@@ -1694,11 +1694,13 @@ key {
   bottom: -1.2em;
   color: var(--text-color);
   line-height: 1em;
-  font-size: .8em;
+  font-size: .75em;
   text-shadow: none;
   padding: 1px;
   left: 0;
   opacity: .5;
+  text-align: center;
+  width: 100%;
 }
 
 .word letter.incorrect.extra {

--- a/public/index.html
+++ b/public/index.html
@@ -1681,6 +1681,20 @@
                 </div>
               </div>
             </div>
+            <div class="section indicateTypos" section="">
+              <h1>indicate typos</h1>
+              <div class="text">
+                Show typos underneath the letters
+              </div>
+              <div class="buttons">
+                <div class="button off" tabindex="0" onclick="this.blur();">
+                  off
+                </div>
+                <div class="button on" tabindex="0" onclick="this.blur();">
+                  on
+                </div>
+              </div>
+            </div>
             <div class="section swapEscAndTab" section="">
               <h1>swap esc and tab</h1>
               <div class="text">

--- a/public/js/commandline.js
+++ b/public/js/commandline.js
@@ -137,6 +137,13 @@ let commands = {
         toggleBlindMode();
       },
     },
+    {
+      id: "toggleIndicateTypos",
+      display: "Toggle indicate typos",
+      exec: () => {
+        toggleIndicateTypos();
+      },
+    },
     // {
     //   id: "toggleReadAheadMode",
     //   display: "Toggle read ahead mode",

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -907,7 +907,7 @@ function compareInput(showError) {
         if (currentWord[i] == undefined) {
           ret += '<letter class="incorrect extra">' + input[i] + "</letter>";
         } else {
-          ret += '<letter class="incorrect">' + currentWord[i] + "</letter>";
+          ret += '<letter class="incorrect">' + currentWord[i] + (config.indicateTypos ? `<hint>${input[i]}</hint>` : '') + "</letter>";
         }
       }
     }

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -136,6 +136,7 @@ settingsGroups.confidenceMode = new SettingsGroup(
     settingsGroups.stopOnError.updateButton();
   }
 );
+settingsGroups.indicateTypos = new SettingsGroup("indicateTypos", setIndicateTypos);
 settingsGroups.blindMode = new SettingsGroup("blindMode", setBlindMode);
 settingsGroups.quickEnd = new SettingsGroup("quickEnd", setQuickEnd);
 // settingsGroups.readAheadMode = new SettingsGroup(

--- a/public/js/userconfig.js
+++ b/public/js/userconfig.js
@@ -36,6 +36,7 @@ let defaultConfig = {
   capsLockBackspace: false,
   layout: "default",
   confidenceMode: "off",
+  indicateTypos: false,
   timerStyle: "text",
   colorfulMode: false,
   randomTheme: "off",
@@ -170,6 +171,7 @@ function applyConfig(configObj) {
     setFlipTestColors(configObj.flipTestColors, true);
     setColorfulMode(configObj.colorfulMode, true);
     setConfidenceMode(configObj.confidenceMode, true);
+    setIndicateTypos(configObj.indicateTypos, true);
     setTimerStyle(configObj.timerStyle, true);
     setTimerColor(configObj.timerColor, true);
     setTimerOpacity(configObj.timerOpacity, true);
@@ -789,6 +791,25 @@ function setConfidenceMode(cm, nosave) {
   updateTestModesNotice();
   if (!nosave) saveConfigToCookie();
 }
+
+
+function toggleIndicateTypos() {
+  it = !config.indicateTypos;
+  if (it == undefined) {
+    it = false;
+  }
+  config.indicateTypos = it;
+  saveConfigToCookie();
+}
+
+function setIndicateTypos(it, nosave) {
+  if (it == undefined) {
+    it = false;
+  }
+  config.indicateTypos = it;
+  if (!nosave) saveConfigToCookie();
+}
+
 
 function previewTheme(name) {
   if (


### PR DESCRIPTION
This feature is somewhat the answer for users that wanted immediate feedback to see what they have typed wrong from probably the ff reasons:

- They're keyboard switches exhibits bouncing but they aren't aware yet
- Reading too fast they'll see that they were typing words ahead instead of the current word
- Wanted to be conscious of their mistakes immediately instead of waiting till the end of the session (and likely to make better approaches the next time they encountered the words)
- Helping to realise their stupidity :) <-- me

There might be other reasons, but ultimately I think a number of MT users will appreciate a similar functionality
