### PR TITLE
Fixed missing 'on' button text in settings under blind mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1556,7 +1556,7 @@
                   off
                 </div>
                 <div class="button on" tabindex="0" onclick="this.blur();">
-                  ⠀
+                  on
                 </div>
               </div>
             </div>


### PR DESCRIPTION
I've described this issue in detail [here](https://github.com/Miodec/monkey-type/issues/409) in detail. Nevertheless, this pull request is about fixing the missing `on` button text in settings under blind mode.
![Screenshot_2020-10-09_08-29-36](https://user-images.githubusercontent.com/38748298/95536839-a0947780-0a09-11eb-945a-cd181fc92454.png)